### PR TITLE
Introduce concurrency option

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "csv-stringify": "^3.0.0",
     "inflection": "^1.12.0",
     "lighthouse": "^2.9.4",
+    "lodash": "^4.17.10",
     "optimist": "^0.6.1",
     "ora": "^2.1.0",
     "pug": "^2.0.3"

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,7 +32,6 @@ const DEFAULT_CONFIG = {
  */
 
 export default class Config {
-  chromePort: number
   private config: any
 
   constructor(configFile) {
@@ -60,8 +59,12 @@ export default class Config {
 
   get chromeOpts() {
     return {
-      chromeFlags: ['--disable-gpu', '--show-paint-rects', '--headless', '--no-sandbox']
+      chromeFlags: ['--disable-gpu', '--headless', '--no-sandbox']
     }
+  }
+
+  get concurrency(): number {
+    return this.config.concurrency ? parseInt(this.config.concurrency, 10) : 1
   }
 
   get reporter(): 'csv' | 'html' {

--- a/src/reporters/csv.ts
+++ b/src/reporters/csv.ts
@@ -4,7 +4,7 @@ import BaseReporter from './base_reporter'
 
 export default class CSVReporter extends BaseReporter implements Reporter {
   write(report: ReportsList, destFileName: string): string {
-    const rows = Object.keys(report).map(url => {
+    const rows = Object.keys(report).sort().map(url => {
       const results = this.config.auditKeys.map(key => report[url][key])
       return [url].concat(results)
     })

--- a/src/reporters/html.ts
+++ b/src/reporters/html.ts
@@ -7,7 +7,7 @@ const template = path.join(process.cwd(), 'templates', 'html.pug')
 
 export default class HTMLReporter extends BaseReporter implements Reporter {
   write(report: ReportsList, destFileName: string): string {
-    const rows = Object.keys(report).map(url => {
+    const rows = Object.keys(report).sort().map(url => {
       const results = this.config.auditKeys.map(key => report[url][key])
       return [url].concat(results)
     })

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,21 +1,32 @@
+import * as chromeLauncher from 'chrome-launcher'
 import { getLighthouseReport } from './lighthouse'
+import { isNumber } from 'lodash'
 import Config from './config'
 
 export default class Runner {
   private config: Config
+  private chrome: chromeLauncher.LaunchedChrome
 
   constructor(config: Config) {
     this.config = config
   }
 
+  async start() {
+    this.chrome = await chromeLauncher.launch({ ...this.config.chromeOpts })
+  }
+
+  async stop() {
+    await this.chrome.kill()
+  }
+
   async runAudit(url): Promise<IAuditReport> {
-    const results = await getLighthouseReport(url, { port: this.config.chromePort }, this.config.lighthouseOpts)
+    const results = await getLighthouseReport(url, { port: this.chrome.port }, this.config.lighthouseOpts)
     delete results.artifacts
 
     const urlReport: IAuditReport = {}
     this.config.auditKeys.forEach(key => {
       const data = results.audits[key] as IAudit
-      urlReport[key] = data.rawValue
+      urlReport[key] = isNumber(data.rawValue) ? Math.round(data.rawValue) : data.rawValue
     })
     return urlReport
   }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,6 +1,6 @@
 interface IAudit {
   name: string
-  rawValue: number | boolean
+  rawValue: any
 }
 
 interface IAuditReport {

--- a/test/index.ts
+++ b/test/index.ts
@@ -57,7 +57,7 @@ test.serial('generate report', async t => {
     // tslint:enable max-line-length
   ].join('\n')
 
-  t.true(t.context.chromeStub.kill.calledOnce)
+  t.true(t.context.chromeStub.kill.called)
   t.is(csv, expectedCsv)
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1977,7 +1977,7 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
 
-lodash@^4.17.4, lodash@^4.3.0:
+lodash@^4.17.10, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 


### PR DESCRIPTION
You can spawn multiple chrome processes and run audits in parallel.

Concurrency is done in a simple batching manner, can be improved in the future.

Some local measurements:
Running with 20 URLs.
With concurrency of 4 - 216.14s
With concurrency of 1 - 687.66s