### PR TITLE
Fix relative pug template problem and strip comments from the generated code

### DIFF
--- a/src/reporters/html.ts
+++ b/src/reporters/html.ts
@@ -2,7 +2,8 @@ import * as path from 'path'
 import * as pug from 'pug'
 import BaseReporter from './base_reporter'
 
-const template = path.join(process.cwd(), 'templates', 'html.pug')
+// We're resolving from '/dest/src/reporters' to '/templates'
+const template = path.join(__dirname, '../../../templates', 'html.pug')
 
 export default class HTMLReporter extends BaseReporter implements Reporter {
   write(report: ReportsList, destFileName: string): string {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
       "esnext.asynciterable",
       "es2017",
       "dom"
-    ]
+    ],
+    "removeComments": true
   },
   "exclude": [
     "dest",


### PR DESCRIPTION
When run from another project as a dependency, rushy fails to resolve template
path since process.cwd() becomes the working directory of a parent project
instead of rushy itself. This is tackled by using __dirname that points to the
dependency directory.

Also, comments were not stripped from the generated code where they're useless
in my opinion.