### PR TITLE
Add workers support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,17 @@ What do next is up to you. For example, you can:
 - commit reports to your git repository
 - upload somewhere
 - build historical data, charts, etc...
+
+### Running in Parallel
+
+The thing you might think about is speeding up your performance checks by making them parallel. Currently, the way to achieve that is to run `rushy` on a few machines or different containers (the "official" one is on the way) so each instance only works on its own slice of an entire URL list.
+
+To do so, please run the tool as the following:
+
+```
+rushy --worker 0 --worker-count=2 --config=[path/to/config.json]
+```
+
+Where `--worker` is zero-based worker number and `--worker-count` stands for the total number of workers you spawn.
+
+Internally, rushy splits the URL list in a 100% deterministic and fair way so it loads your workers evenly and each URL is never checked twice.

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
   },
   "ava": {
     "files": [
-      "dest/test/index.js"
+      "dest/test/index.js",
+      "dest/test/get_even_slice.js"
     ]
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,6 @@ const DEFAULT_CONFIG = {
   reporter: 'csv',
   storeDir: 'tmp',
   logger: 'inline',
-  concurrency: 1,
   reportQuery: {
     'Score': '$.reportCategories[0].score',
     'Time to First Byte': '$.audits["time-to-first-byte"].rawValue',
@@ -36,7 +35,6 @@ const DEFAULT_CONFIG = {
  * Options:
  * `urls` - the list of pages to run audits on.
  * `storeDir` - the directory for storing reports.
- * `concurrency` - the number of Chrome/Lighthouse processes to launch simultaneously.
  * `logger` - progress logger to use.
  *   - `inline` works as a spinner with current status.
  *   - `serial` just logs steps line by line (suitable for CI logs, for example).
@@ -74,10 +72,6 @@ export default class Config {
 
   get reportQuery(): any {
     return this.config.reportQuery
-  }
-
-  get concurrency(): number {
-    return this.config.concurrency
   }
 
   get logger(): 'inline' | 'serial' {

--- a/src/generate_report.ts
+++ b/src/generate_report.ts
@@ -1,110 +1,51 @@
-import { padStart } from 'lodash'
-
 import Config from './config'
 import InlineLogger from './loggers/inline'
 import SerialLogger from './loggers/serial'
 import CSVReporter from './reporters/csv'
 import HTMLReporter from './reporters/html'
 import Runner from './runner'
+import getEvenSlice from './helpers/get_even_slice'
+import ProgressLogger from './helpers/progress_logger'
 
-function splitIntoGroups(collection, groupSize): string[][] {
-  const results: string[][] = []
-  let start = 0
-  let end = groupSize
-  let group = collection.slice(start, end)
-
-  while (group.length > 0) {
-    results.push(group)
-    start += groupSize
-    end += groupSize
-    group = collection.slice(start, end)
-  }
-
-  return results
-}
-
-export default async function generateReport(configFile: string, destFileName: string) {
+export default async function generateReport(configFile: string,
+                                             destFileName: string,
+                                             worker: number,
+                                             workerCount: number) {
   const config = new Config(configFile)
   const logger = config.logger === 'inline' ? new InlineLogger() : new SerialLogger()
   const reporter = config.reporter === 'csv' ? new CSVReporter(config) : new HTMLReporter(config)
 
-  // const spinner = ora('Launching Chrome').start()
+  const report: ReportsList = {}
+
   logger.info('Launching Chrome')
+
+  const runner = new Runner(config)
+  await runner.start()
 
   process.on('SIGINT', async () => {
     logger.error('Interrupted', { persist: true })
+    // Kill Chrome processes on interruption
+    await runner.stop()
   })
 
-  logger.info('Starting pool of lighthouse workers')
+  const urlSlice = getEvenSlice(config.urls, workerCount, worker)
+  const progressLogger = new ProgressLogger(urlSlice, config.logger, logger)
 
-  const pool: Runner[] = []
+  logger.info(`Starting processing ${urlSlice.length} URLs`)
 
-  // Kill Chrome processes on interruption
-  process.on('SIGINT', async () => {
-    for (const worker of pool) {
-      await worker.stop()
+  for (const url of urlSlice) {
+    progressLogger.update(url)
+
+    try {
+      report[url] = await runner.runAudit(url)
+    } catch (error) {
+      logger.error(`Something went wrong for ${url}: ${error}`, { persist: true })
+      report[url] = {}
     }
-  })
-
-  for (let i = 0; i <= config.concurrency; i++) {
-    const runner = new Runner(config)
-    await runner.start()
-    pool.push(runner)
   }
 
-  const urlGroups = splitIntoGroups(config.urls, config.concurrency)
-
-  const report: ReportsList = {}
-
-  let processed = 0
-  let remaining = config.urls.length
-  let reported
-
-  function reportProgress() {
-    if (reported === remaining) return
-
-    if (config.logger === 'inline') {
-      logger.info([
-        'Running pages audit',
-        '',
-        `  Concurrency     ${padStart(config.concurrency, 3)}`,
-        `  Total pages     ${padStart(config.urls.length, 3)}`,
-        '',
-        `  Processed pages ${padStart(processed, 3)}`,
-        `  Remaining pages ${padStart(remaining, 3)}`
-      ].join('\n'))
-    } else {
-      logger.info(
-        `Remaining pages: ${remaining}`
-      )
-    }
-
-    reported = remaining
-  }
-
-  for (const group of urlGroups) {
-    await Promise.all(
-      group.map(async (url, i) => {
-        reportProgress()
-
-        try {
-          report[url] = await pool[i].runAudit(url)
-        } catch (error) {
-          report[url] = {}
-        }
-
-        remaining--
-        processed++
-        reportProgress()
-      })
-    )
-  }
-
-  logger.info('Shutting down workers')
-
-  for (const worker of pool) {
-    await worker.stop()
-  }
+  logger.info('Shutting down Chrome')
+  await runner.stop()
 
   logger.info('Saving report')
   const reportFileName = reporter.write(report, `${destFileName}.${reporter.ext}`)

--- a/src/helpers/get_even_slice.ts
+++ b/src/helpers/get_even_slice.ts
@@ -1,0 +1,12 @@
+function getEvenSlice(list: string[], slices: number, index: number): string[] {
+  const largeSlices: number = list.length % slices
+  const large: number = Math.ceil(list.length / slices)
+  const normal: number = Math.floor(list.length / slices)
+
+  const start = Math.min(index, largeSlices) * large + Math.max(0, index - largeSlices) * normal
+  const end = start + (index < largeSlices ? large : normal)
+
+  return list.slice(start, end)
+}
+
+export default getEvenSlice

--- a/src/helpers/progress_logger.ts
+++ b/src/helpers/progress_logger.ts
@@ -1,0 +1,46 @@
+import { padStart } from 'lodash'
+
+export default class ProgressLogger {
+  private urls: string[]
+  private type: string
+  private logger: Logger
+  private processed: number
+
+  constructor (urls: string[], type: string, logger: Logger) {
+    this.urls = urls
+    this.type = type
+    this.logger = logger
+    this.processed = 0
+  }
+
+  public update (url: string): void {
+    this.processed++
+
+    switch (this.type) {
+      case 'inline':
+        this.updateInline(url)
+        break
+       case 'serial':
+         this.updateSerial(url)
+         break
+    }
+  }
+
+  private updateInline (url: string): void {
+    this.logger.info([
+      'Analyzing page performance:',
+      `  ${url}`,
+      '',
+      `  Total pages     ${padStart(this.urls.length, 3)}`,
+      `  Remaining pages ${padStart(this.getRemaining(), 3)}`
+    ].join('\n'), { persist: false })
+  }
+
+  private updateSerial (url: string): void {
+    this.logger.info(`Analyzing: ${url}, remaining: ${this.getRemaining()}`, { persist: false })
+  }
+
+  private getRemaining(): number {
+    return this.urls.length - this.processed
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,34 @@
 
 import * as optimist from 'optimist'
 import generateReport from './generate_report'
+import { existsSync } from 'fs'
 
-const configFileName = optimist.argv.config
+const argv = optimist
+  .usage('$0 --config=[file] --worker=[num] --worker-count=[num]')
+  .demand(['config'])
+  .default('worker', 0)
+  .default('worker-count', 1)
+  .check(options => {
+    if (!existsSync(options.config)) {
+      throw new Error(`Can't load config from ${options.config}`)
+    }
+
+    if (options['worker-count'] <= 0) {
+      throw new Error('--worker-count must be >= 1')
+    }
+
+    if (options.worker >= options['worker-count']) {
+      throw new Error('--worker must be < --worker-count')
+    }
+
+    return true
+  })
+  .argv
+
+const configFileName = argv.config
+const workerCount = argv['worker-count']
+const worker = argv.worker
 const destFileName = (new Date()).toISOString()
 
-generateReport(configFileName, destFileName)
+generateReport(configFileName, destFileName, worker, workerCount)
   .then(() => process.exit())

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,8 +18,8 @@ const argv = optimist
       throw new Error('--worker-count must be >= 1')
     }
 
-    if (options.worker >= options['worker-count']) {
-      throw new Error('--worker must be < --worker-count')
+    if (options.worker < 0 || options.worker >= options['worker-count']) {
+      throw new Error('--worker must be < --worker-count && > 0')
     }
 
     return true

--- a/test/get_even_slice.ts
+++ b/test/get_even_slice.ts
@@ -1,0 +1,37 @@
+import { test } from 'ava'
+import getEvenSlice from '../src/helpers/get_even_slice'
+
+const list: string[] = ['1','2','3','4','5','6']
+
+test('slice evenly when modulo = 0', t => {
+  t.deepEqual(getEvenSlice(list, 3, 0), ['1','2'])
+  t.deepEqual(getEvenSlice(list, 3, 1), ['3','4'])
+  t.deepEqual(getEvenSlice(list, 3, 2), ['5','6'])
+})
+
+test('slice evenly when remainder is non-zero', t => {
+  const largeList: string[] = ['1','2','3','4','5','6','7','8']
+  t.deepEqual(getEvenSlice(largeList, 3, 0), ['1','2','3'])
+  t.deepEqual(getEvenSlice(largeList, 3, 1), ['4','5','6'])
+  t.deepEqual(getEvenSlice(largeList, 3, 2), ['7','8'])
+})
+
+test('return empty list for an empty list', t => {
+  t.deepEqual(getEvenSlice([], 3, 0), [])
+})
+
+test('return empty lists for non-existent slices', t => {
+  t.deepEqual(getEvenSlice(list, 8, 0), ['1'])
+  t.deepEqual(getEvenSlice(list, 8, 1), ['2'])
+  t.deepEqual(getEvenSlice(list, 8, 2), ['3'])
+  t.deepEqual(getEvenSlice(list, 8, 3), ['4'])
+  t.deepEqual(getEvenSlice(list, 8, 4), ['5'])
+  t.deepEqual(getEvenSlice(list, 8, 5), ['6'])
+  t.deepEqual(getEvenSlice(list, 8, 6), [])
+  t.deepEqual(getEvenSlice(list, 8, 7), [])
+})
+
+test('slice once and return no additional slices', t => {
+  t.deepEqual(getEvenSlice(list, 1, 0), list)
+  t.deepEqual(getEvenSlice(list, 1, 1), [])
+})

--- a/test/get_even_slice.ts
+++ b/test/get_even_slice.ts
@@ -1,19 +1,19 @@
 import { test } from 'ava'
 import getEvenSlice from '../src/helpers/get_even_slice'
 
-const list: string[] = ['1','2','3','4','5','6']
+const list: string[] = ['1', '2', '3', '4', '5', '6']
 
 test('slice evenly when modulo = 0', t => {
-  t.deepEqual(getEvenSlice(list, 3, 0), ['1','2'])
-  t.deepEqual(getEvenSlice(list, 3, 1), ['3','4'])
-  t.deepEqual(getEvenSlice(list, 3, 2), ['5','6'])
+  t.deepEqual(getEvenSlice(list, 3, 0), ['1', '2'])
+  t.deepEqual(getEvenSlice(list, 3, 1), ['3', '4'])
+  t.deepEqual(getEvenSlice(list, 3, 2), ['5', '6'])
 })
 
 test('slice evenly when remainder is non-zero', t => {
-  const largeList: string[] = ['1','2','3','4','5','6','7','8']
-  t.deepEqual(getEvenSlice(largeList, 3, 0), ['1','2','3'])
-  t.deepEqual(getEvenSlice(largeList, 3, 1), ['4','5','6'])
-  t.deepEqual(getEvenSlice(largeList, 3, 2), ['7','8'])
+  const largeList: string[] = ['1', '2', '3', '4', '5', '6', '7', '8']
+  t.deepEqual(getEvenSlice(largeList, 3, 0), ['1', '2', '3'])
+  t.deepEqual(getEvenSlice(largeList, 3, 1), ['4', '5', '6'])
+  t.deepEqual(getEvenSlice(largeList, 3, 2), ['7', '8'])
 })
 
 test('return empty list for an empty list', t => {

--- a/test/index.ts
+++ b/test/index.ts
@@ -55,7 +55,7 @@ test.afterEach(t => {
 })
 
 test.serial('generate report', async t => {
-  await generateReport('./test/config_all.json', 'report_all')
+  await generateReport('./test/config_all.json', 'report_all', 0, 1)
   const csv = fs.readFileSync('test/tmp/report_all.csv').toString()
 
   const expectedCsv = [
@@ -71,7 +71,7 @@ test.serial('generate report', async t => {
 })
 
 test.serial('generate report with custom query', async t => {
-  await generateReport('./test/config_custom_query.json', 'report_custom_query')
+  await generateReport('./test/config_custom_query.json', 'report_custom_query', 0, 1)
   const csv = fs.readFileSync('test/tmp/report_custom_query.csv').toString()
 
   const expectedCsv = [
@@ -84,7 +84,7 @@ test.serial('generate report with custom query', async t => {
 })
 
 test.serial('generate report with html reporter', async t => {
-  await generateReport('./test/config_html.json', 'report_html')
+  await generateReport('./test/config_html.json', 'report_html', 0, 1)
   const html = fs.readFileSync('test/tmp/report_html.html').toString()
 
   t.true(html.includes('<th>Time to First Byte</th>'))


### PR DESCRIPTION
In order to support checks parallelization I add `--workers` and `--workers-count` CLI arguments. They make rushy split the URL list from config into separate chunks (`worker-count`) and process only the one specified by `worker`. 

I also got rid of concurrency since it wasn't used, combed the code a bit, configured `optimist` to be more restrictive on the arguments and introduced `ProgressLogger` class to make encapsulation a bit better.