### PR TITLE
Fix report naming issue #9 and quit if URLs list is empty

### DIFF
--- a/src/generate_report.ts
+++ b/src/generate_report.ts
@@ -16,13 +16,6 @@ export default async function generateReport(configFile: string,
   const reporter = config.reporter === 'csv' ? new CSVReporter(config) : new HTMLReporter(config)
 
   const report: ReportsList = {}
-
-  process.on('SIGINT', async () => {
-    logger.error('Interrupted', { persist: true })
-    // Kill Chrome processes on interruption
-    await runner.stop()
-  })
-
   const urlSlice = getEvenSlice(config.urls, workerCount, worker)
   const progressLogger = new ProgressLogger(urlSlice, config.logger, logger)
 
@@ -36,6 +29,12 @@ export default async function generateReport(configFile: string,
   logger.info('Launching Chrome')
   const runner = new Runner(config)
   await runner.start()
+
+  process.on('SIGINT', async () => {
+    logger.error('Interrupted', { persist: true })
+    // Kill Chrome processes on interruption
+    await runner.stop()
+  })
 
   for (const url of urlSlice) {
     progressLogger.update(url)

--- a/src/generate_report.ts
+++ b/src/generate_report.ts
@@ -17,11 +17,6 @@ export default async function generateReport(configFile: string,
 
   const report: ReportsList = {}
 
-  logger.info('Launching Chrome')
-
-  const runner = new Runner(config)
-  await runner.start()
-
   process.on('SIGINT', async () => {
     logger.error('Interrupted', { persist: true })
     // Kill Chrome processes on interruption
@@ -31,7 +26,16 @@ export default async function generateReport(configFile: string,
   const urlSlice = getEvenSlice(config.urls, workerCount, worker)
   const progressLogger = new ProgressLogger(urlSlice, config.logger, logger)
 
+  if (urlSlice.length === 0) {
+    logger.info(`No URLs to process for worker=${worker} of workerCount=${workerCount}, shutting down`)
+    process.exit(0)
+  }
+
   logger.info(`Starting processing ${urlSlice.length} URLs`)
+
+  logger.info('Launching Chrome')
+  const runner = new Runner(config)
+  await runner.start()
 
   for (const url of urlSlice) {
     progressLogger.update(url)

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ const argv = optimist
 const configFileName = argv.config
 const workerCount = argv['worker-count']
 const worker = argv.worker
-const destFileName = (new Date()).toISOString()
+const destFileName = (workerCount > 1 ? `worker_${worker}_` : '') + (new Date()).toISOString()
 
 generateReport(configFileName, destFileName, worker, workerCount)
   .then(() => process.exit())


### PR DESCRIPTION
Currently, reports are given names only in regards to generation datetime.
Althought it's quite unlikely to happen, rushy might be called at the same
millisecond therefore causing the reports to have the same name - and one
of them lost. We fix this by adding worker_N prefix to report filename.

It will also optimize a bit how we handle an empty URL list by making rushy
explicitly report this and exit with code 0.

Fixes #9.